### PR TITLE
Fix ChatChannelViewModel initial state when chat was open via notification tap

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -13,8 +13,6 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
 
     @StateObject private var viewModel: ChatChannelViewModel
 
-    @Environment(\.presentationMode) var presentationMode
-
     @State private var messageDisplayInfo: MessageDisplayInfo?
     @State private var keyboardShown = false
     @State private var tabBarAvailable: Bool = false
@@ -163,13 +161,6 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         .onDisappear {
             viewModel.onViewDissappear()
         }
-        .onChange(of: presentationMode.wrappedValue, perform: { newValue in
-            if newValue.isPresented == false {
-                viewModel.onViewDissappear()
-            } else {
-                viewModel.setActive()
-            }
-        })
         .background(
             isIphone ?
                 Color.clear.background(

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -13,6 +13,8 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
 
     @StateObject private var viewModel: ChatChannelViewModel
 
+    @Environment(\.presentationMode) var presentationMode
+
     @State private var messageDisplayInfo: MessageDisplayInfo?
     @State private var keyboardShown = false
     @State private var tabBarAvailable: Bool = false
@@ -161,6 +163,13 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         .onDisappear {
             viewModel.onViewDissappear()
         }
+        .onChange(of: presentationMode.wrappedValue, perform: { newValue in
+            if newValue.isPresented == false {
+                viewModel.onViewDissappear()
+            } else {
+                viewModel.setActive()
+            }
+        })
         .background(
             isIphone ?
                 Color.clear.background(

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -25,7 +25,12 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
-    private var isActive = true
+    private var isAppeared = false
+    private var isForegrounded = UIApplication.shared.applicationState == .active
+    private var isActive: Bool {
+        isAppeared && isForegrounded
+    }
+    
     private var readsString = ""
     
     private let messageListDateOverlay: DateFormatter = DateFormatter.messageListDateOverlay
@@ -140,6 +145,20 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
             object: nil
         )
         
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(willEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        
         if messageController == nil {
             NotificationCenter.default.addObserver(
                 self,
@@ -165,6 +184,23 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     private func didReceiveMemoryWarning() {
         Nuke.ImageCache.shared.removeAll()
         messageCachingUtils.clearCache()
+    }
+    
+    @objc
+    private func willEnterForeground() {
+        let wasActive = isActive
+        
+        isForegrounded = true
+        
+        if !wasActive && isActive {
+            didBecomeActive()
+        }
+    }
+    
+    
+    @objc
+    private func didEnterBackground() {
+        isForegrounded = false
     }
     
     public func scrollToLastMessage() {
@@ -291,17 +327,17 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     }
     
     public func onViewAppear() {
-        setActive()
-        messages = channelDataSource.messages
-        checkNameChange()
+        let wasActive = isActive
+        
+        isAppeared = true
+        
+        if !wasActive && isActive {
+            didBecomeActive()
+        }
     }
     
     public func onViewDissappear() {
-        isActive = false
-    }
-    
-    public func setActive() {
-        isActive = true
+        isAppeared = false
     }
     
     // MARK: - private
@@ -505,6 +541,11 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         if shouldShow != shouldShowTypingIndicator {
             shouldShowTypingIndicator = shouldShow
         }
+    }
+    
+    private func didBecomeActive() {        
+        messages = channelDataSource.messages
+        checkNameChange()
     }
     
     deinit {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -25,12 +25,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
-    private var isAppeared = false
-    private var isForegrounded = UIApplication.shared.applicationState == .active
-    private var isActive: Bool {
-        isAppeared && isForegrounded
-    }
-    
+    private var isActive = true
     private var readsString = ""
     
     private let messageListDateOverlay: DateFormatter = DateFormatter.messageListDateOverlay
@@ -145,20 +140,6 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
             object: nil
         )
         
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(willEnterForeground),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didEnterBackground),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil
-        )
-        
         if messageController == nil {
             NotificationCenter.default.addObserver(
                 self,
@@ -184,23 +165,6 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     private func didReceiveMemoryWarning() {
         Nuke.ImageCache.shared.removeAll()
         messageCachingUtils.clearCache()
-    }
-    
-    @objc
-    private func willEnterForeground() {
-        let wasActive = isActive
-        
-        isForegrounded = true
-        
-        if !wasActive && isActive {
-            didBecomeActive()
-        }
-    }
-    
-    
-    @objc
-    private func didEnterBackground() {
-        isForegrounded = false
     }
     
     public func scrollToLastMessage() {
@@ -327,17 +291,17 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     }
     
     public func onViewAppear() {
-        let wasActive = isActive
-        
-        isAppeared = true
-        
-        if !wasActive && isActive {
-            didBecomeActive()
-        }
+        setActive()
+        messages = channelDataSource.messages
+        checkNameChange()
     }
     
     public func onViewDissappear() {
-        isAppeared = false
+        isActive = false
+    }
+    
+    public func setActive() {
+        isActive = true
     }
     
     // MARK: - private
@@ -541,11 +505,6 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         if shouldShow != shouldShowTypingIndicator {
             shouldShowTypingIndicator = shouldShow
         }
-    }
-    
-    private func didBecomeActive() {        
-        messages = channelDataSource.messages
-        checkNameChange()
     }
     
     deinit {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -26,9 +26,9 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     }
 
     private var isAppeared = false
-    private var isForegrounded = UIApplication.shared.applicationState == .active
+    private var isBackgrounded = UIApplication.shared.applicationState == .background
     private var isActive: Bool {
-        isAppeared && isForegrounded
+        isAppeared && !isBackgrounded
     }
     
     private var readsString = ""
@@ -190,7 +190,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     private func willEnterForeground() {
         let wasActive = isActive
         
-        isForegrounded = true
+        isBackgrounded = false
         
         if !wasActive && isActive {
             didBecomeActive()
@@ -200,7 +200,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     
     @objc
     private func didEnterBackground() {
-        isForegrounded = false
+        isBackgrounded = true
     }
     
     public func scrollToLastMessage() {


### PR DESCRIPTION
The following initiliasation was wrong because there are two foregrounded states: `.active`, `.inactive`.

```swift
private var isForegrounded = UIApplication.shared.applicationState == .active
```

So, the fix could be:
```swift
private var isForegrounded = UIApplication.shared.applicationState != .background
```

But I fixed it as below to make the code easier to read:
```swift
private var isBackgrounded = UIApplication.shared.applicationState == .background
```

The following tests are done:

__Bug fix__
- [x] A is in inbox. A background the app. B sends A a chat message. A taps notif and the app opens to chat with B. A sends message. Verify the sent message appears in the chat thread.

__No regression__ (messages are not marked read while backgrounded)
- [x] A is in chat with B. A background the app. B sends A a chat message. A gets notif and app icon badge. Verify the badge persists until A opens the app.